### PR TITLE
live_axis_range: Add params to set min range width and range limit

### DIFF
--- a/pglive/examples_pyqt5/__init__.py
+++ b/pglive/examples_pyqt5/__init__.py
@@ -18,6 +18,18 @@ def stop():
     running = False
     app.exit(0)
 
+def sin_wave_add_square_wave_generator(*data_connectors, flip=False):
+    """Sine wave + Square Wave generator"""
+    x = 0
+    while running:
+        x += 1
+        square_wave_amplitude = 0 if x // 750 % 2 == 0 else 5
+        for data_connector in data_connectors:
+            if flip:
+                data_connector.cb_append_data_point(x, sin(x * 0.025) + square_wave_amplitude)
+            else:
+                data_connector.cb_append_data_point(sin(x * 0.025) + square_wave_amplitude, x)
+        sleep(0.01)
 
 def sin_wave_generator(*data_connectors, flip=False):
     """Sine wave generator"""

--- a/pglive/examples_pyqt5/live_plot_range.py
+++ b/pglive/examples_pyqt5/live_plot_range.py
@@ -18,6 +18,7 @@ layout = pg.LayoutWidget()
 layout.layout.setSpacing(0)
 args = []
 args2 = []
+args3 = []
 
 '''
 Move view to the right on every 300 ticks (data update).
@@ -146,9 +147,45 @@ args.append(DataConnector(plot, max_points=600))
 layout.addWidget(time_axis_plot_widget, row=2, col=2)
 
 # ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=0)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_range_limit set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Range Limit -1.0, 1.0",
+                        y_range_controller=LiveAxisRange(y_range_limit=[-1.0, 1.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=1)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width and y_range_limit set.
+
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0 @ Range Limit -1.0, 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-1.0, 3.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=2)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
 
 layout.show()
 Thread(target=examples.sin_wave_generator, args=args).start()
 Thread(target=examples.sin_wave_generator, args=args2, kwargs={"flip": True}).start()
+Thread(target=examples.sin_wave_add_square_wave_generator, args=args3).start()
 examples.app.exec()
 examples.stop()

--- a/pglive/examples_pyqt6/__init__.py
+++ b/pglive/examples_pyqt6/__init__.py
@@ -18,6 +18,18 @@ def stop():
     running = False
     app.exit(0)
 
+def sin_wave_add_square_wave_generator(*data_connectors, flip=False):
+    """Sine wave + Square Wave generator"""
+    x = 0
+    while running:
+        x += 1
+        square_wave_amplitude = 0 if x // 750 % 2 == 0 else 5
+        for data_connector in data_connectors:
+            if flip:
+                data_connector.cb_append_data_point(x, sin(x * 0.025) + square_wave_amplitude)
+            else:
+                data_connector.cb_append_data_point(sin(x * 0.025) + square_wave_amplitude, x)
+        sleep(0.01)
 
 def sin_wave_generator(*data_connectors, flip=False):
     """Sine wave generator"""

--- a/pglive/examples_pyqt6/live_plot_range.py
+++ b/pglive/examples_pyqt6/live_plot_range.py
@@ -18,6 +18,7 @@ layout = pg.LayoutWidget()
 layout.layout.setSpacing(0)
 args = []
 args2 = []
+args3 = []
 
 '''
 Move view to the right on every 300 ticks (data update).
@@ -146,9 +147,45 @@ args.append(DataConnector(plot, max_points=600))
 layout.addWidget(time_axis_plot_widget, row=2, col=2)
 
 # ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=0)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_range_limit set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Range Limit -1.0, 1.0",
+                        y_range_controller=LiveAxisRange(y_range_limit=[-1.0, 1.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=1)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width and y_range_limit set.
+
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0 @ Range Limit -1.0, 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-1.0, 3.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=2)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
 
 layout.show()
 Thread(target=examples.sin_wave_generator, args=args).start()
 Thread(target=examples.sin_wave_generator, args=args2, kwargs={"flip": True}).start()
+Thread(target=examples.sin_wave_add_square_wave_generator, args=args3).start()
 examples.app.exec()
 examples.stop()

--- a/pglive/examples_pyside6/__init__.py
+++ b/pglive/examples_pyside6/__init__.py
@@ -18,6 +18,18 @@ def stop():
     running = False
     app.exit(0)
 
+def sin_wave_add_square_wave_generator(*data_connectors, flip=False):
+    """Sine wave + Square Wave generator"""
+    x = 0
+    while running:
+        x += 1
+        square_wave_amplitude = 0 if x // 750 % 2 == 0 else 5
+        for data_connector in data_connectors:
+            if flip:
+                data_connector.cb_append_data_point(x, sin(x * 0.025) + square_wave_amplitude)
+            else:
+                data_connector.cb_append_data_point(sin(x * 0.025) + square_wave_amplitude, x)
+        sleep(0.01)
 
 def sin_wave_generator(*data_connectors, flip=False):
     """Sine wave generator"""

--- a/pglive/examples_pyside6/live_plot_range.py
+++ b/pglive/examples_pyside6/live_plot_range.py
@@ -18,6 +18,7 @@ layout = pg.LayoutWidget()
 layout.layout.setSpacing(0)
 args = []
 args2 = []
+args3 = []
 
 '''
 Move view to the right on every 300 ticks (data update).
@@ -146,10 +147,46 @@ args.append(DataConnector(plot, max_points=600))
 layout.addWidget(time_axis_plot_widget, row=2, col=2)
 
 # ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=0)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_range_limit set.
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Range Limit -1.0, 1.0",
+                        y_range_controller=LiveAxisRange(y_range_limit=[-1.0, 1.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=1)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
+
+# ---
+'''
+Move view to the right on every 300 ticks (data update).
+Y range is automatically adjudicating every tick according to y_min_range_width and y_range_limit set.
+
+'''
+widget = LivePlotWidget(title=f"Rolling X view range, auto Y range @ 100Hz @ Min Range Width 3.0 @ Range Limit -1.0, 3.0",
+                        y_range_controller=LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-1.0, 3.0]))
+plot = LiveLinePlot(pen="green")
+widget.addItem(plot)
+layout.addWidget(widget, row=3, col=2)
+args3.append(DataConnector(plot, max_points=300, update_rate=100))
 
 layout.show()
 Thread(target=examples.sin_wave_generator, args=args).start()
 Thread(target=examples.sin_wave_generator, args=args2, kwargs={"flip": True}).start()
+Thread(target=examples.sin_wave_add_square_wave_generator, args=args3).start()
 
 signal.signal(signal.SIGINT, lambda sig, frame: examples.stop())
 examples.app.exec()


### PR DESCRIPTION
# Description of Changes
This PR adds 2 new features to the `LiveAxisRange` Class along with 3 examples demonstrating its functionalities.

In one of our application, we use `pglive` to display real-time low bit resolution data (12bit raw data code converted to f32 data) collected from an embedded device. As the auto range algorithm zooms into the plotted line too closely, the plotted line looks very choppy due to the quantization step.

Since we know the exact display range and the size of each quantization step, we add the these two features to mitigate this unwanted auto range algorithm behavior. I think these two features are also useful for other users plotting data of the embedded devices.

##  1. min_range_width
- This sets a minimum display range width to data points being plotted.
## 2. range_limit
- This sets the upper and lower bound of display range to data points being plotted. This parameter can be used alongside with `min_range_width`. `range_limit` has a higher priority than `min_range_width`.

![Screencast From 2025-02-14 13-30-38](https://github.com/user-attachments/assets/162c3bd6-90a7-42ff-8d1e-37b59409d5a4)

Any comments are appreciated.