### PR TITLE
Fix numpy `VisibleDeprecationWarning` compatibility for numpy `>= 1.25`

### DIFF
--- a/pglive/sources/data_connector.py
+++ b/pglive/sources/data_connector.py
@@ -13,7 +13,12 @@ from pyqtgraph.Qt import QtCore  # type: ignore
 from pglive.sources.live_plot import MixinLivePlot, MixinLiveBarPlot, make_live
 from pglive.sources.utils import NUM_LIST, NUM
 
-warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+# numpy >= 1.25 compatibility
+try:
+    from numpy.exceptions import VisibleDeprecationWarning
+except ImportError:
+    from numpy import VisibleDeprecationWarning
+warnings.filterwarnings("ignore", category=VisibleDeprecationWarning)
 
 
 class DataConnector(QtCore.QObject):


### PR DESCRIPTION
- Update warning filter to handle `VisibleDeprecationWarning`'s new location in `numpy.exceptions`
- Add backwards compatibility for older numpy versions

The error starts to appear in numpy version `>2.0`:
```
AttributeError: module 'numpy' has no attribute 'VisibleDeprecationWarning'
```