### PR TITLE
live_axis_range: correct range_limit calculations

### DIFF
--- a/pglive/sources/live_axis_range.py
+++ b/pglive/sources/live_axis_range.py
@@ -219,15 +219,16 @@ class LiveAxisRange:
                 final_range[1] = center_pt + range_width / 2
 
         if bound is not None:
-            final_range_width = abs(final_range[0] - final_range[1])
-            if (bound[0] > final_range[1] and bound[0] > final_range[0]) or \
-                (bound[1] < final_range[1] and bound[0] < final_range[0]) or \
-                (bound[0] > final_range[0] and bound[1] < final_range[1]):
-                final_range = bound
-            elif bound[1] > final_range[0] and final_range[0] > bound[0]:
-                final_range = [max(bound[1] - final_range_width, bound[0]), bound[1]]
-            elif bound[0] < final_range[1] and final_range[1] < bound[1]:
-                final_range = [bound[0], min(bound[0] + final_range_width, bound[1])]
+            if range_width is not None:
+                if final_range[1] > bound[1]:
+                    final_range = [max(min(bound[1] - range_width, final_range[0]), bound[0]), bound[1]]
+                elif bound[0] > final_range[0]:
+                    final_range = [bound[0], min(max(bound[0] + range_width, final_range[1]), bound[1])]
+            else:
+                if final_range[1] > bound[1] or bound[0] > final_range[1]:
+                    final_range = [max(final_range[0], bound[0]), bound[1]]
+                if bound[0] > final_range[0] or final_range[0] > bound[1]:
+                    final_range = [bound[0], min(final_range[1], bound[1])]
         return final_range
 
     def ignore_connector(self, data_connector, flag: bool) -> None:


### PR DESCRIPTION
# Description of Changes
Those if-cases I wrote on range_limit were unnecessarily complicated and had errors in some cases. This PR fixes them. This PR also changes the min_range_width behavior when it is used with range_limit.

# Test Case
You can modify the LiveAxisRange in the [example](https://github.com/domarm-comat/pglive/blob/76185c40850b607d9a83843292748463fcaa8089/pglive/examples_pyqt6/live_plot_range.py#L180) to test. Here are a few examples I run.

1. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-1.0, float("inf")])
2. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-1.0, 1.0])
3. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[0.0, 1.0])
4. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[float("-inf"), 1.0])
5. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[-0.5, 0.5])
6. LiveAxisRange(y_min_range_width=3.0, y_range_limit=[float("-inf"), float("inf")])
7. LiveAxisRange(y_range_limit=[0.0, float("inf")])
8. LiveAxisRange(y_range_limit=[float("-inf"), 10.0])
9. LiveAxisRange(y_range_limit=[0.0, 1.0])

Just in case I missed some edge cases. Can you run a few more tests before merging? Thanks. 